### PR TITLE
Fix: #11. Configure logging with rfc5424.

### DIFF
--- a/python-flask-spid/api.py
+++ b/python-flask-spid/api.py
@@ -1,12 +1,11 @@
 import datetime
 from os.path import join as pjoin
-
-from decorator import decorator
+from random import randint
 
 from connexion import problem
+from decorator import decorator
 from flask import current_app as app
 from flask import request, session
-from random import randint
 from spid import init_saml_auth, prepare_flask_request
 
 
@@ -85,8 +84,7 @@ def get_status():
 
 def index():
     req = prepare_flask_request(request)
-    auth = init_saml_auth(req, app.config)
-    errors = []
+    init_saml_auth(req, app.config)
     return {
         "message": "Welcome to the Jungle 1",
         "_links": [

--- a/python-flask-spid/docker-entrypoint.py
+++ b/python-flask-spid/docker-entrypoint.py
@@ -6,14 +6,13 @@
 
 from argparse import ArgumentParser
 from os import mkdir
-from os.path import exists, isdir, isfile
+from os.path import exists
 from os.path import join as pjoin
 from shlex import split
 from socket import gethostbyname, gethostname
 from subprocess import check_output
 
 import yaml
-from six.moves.urllib.request import urlopen
 
 # Default  settings.
 hostname = gethostbyname(gethostname())

--- a/python-flask-spid/index.py
+++ b/python-flask-spid/index.py
@@ -1,22 +1,32 @@
 import argparse
-import logging
 from base64 import decodestring
-from os.path import dirname
-from os.path import join as pjoin
+from logging import basicConfig
+from logging.config import dictConfig
+from os.path import dirname, isfile, join as pjoin
 
 import connexion
+import yaml
+from flask import current_app as app
 from flask import request
 
-logging.basicConfig(level=logging.DEBUG)
-log = logging.getLogger()
+
+def configure_logger(log_config='logging.yaml'):
+    """Configure the logging subsystem."""
+    if not isfile(log_config):
+        return basicConfig()
+
+    with open(log_config) as fh:
+        log_config = yaml.load(fh)
+        return dictConfig(log_config)
 
 
 def log_it():
     saml_response = request.form.get("SAMLResponse", "")
-    log.debug(decodestring(saml_response))
+    app.logger.debug(decodestring(saml_response))
 
 
 if __name__ == "__main__":
+    configure_logger()
     parser = argparse.ArgumentParser()
 
     parser.add_argument(

--- a/python-flask-spid/logging.yaml
+++ b/python-flask-spid/logging.yaml
@@ -1,0 +1,26 @@
+#
+# Flask log configuration.
+#
+version: 1
+formatters:
+  # Avoid Flask sending the timestamp twice in the message.
+  fmt_syslog:
+    format: '%(levelname)s in %(module)s: %(message)s'
+handlers:
+  syslog:
+    class: logging.handlers.SysLogHandler
+    level: DEBUG
+  # This handler converts log in UTC before sending them to syslog.
+  rfc5424:
+    class: rfc5424logging.Rfc5424SysLogHandler
+    level: DEBUG
+    utc_timestamp: True
+    formatter: fmt_syslog
+    address: [172.19.0.1, 514]
+# Use the rfc5424 handler by default.
+root:
+  level: DEBUG
+  handlers:
+  - rfc5424
+
+

--- a/python-flask-spid/requirements.txt
+++ b/python-flask-spid/requirements.txt
@@ -3,9 +3,9 @@ pyOpenSSL==18.0.0
 python-saml==2.4.2
 decorator==4.3.0
 nose
-isort
-autopep8
+rfc5424-logging-handler
 swagger-ui-bundle==0.0.2
+
 # Use development version which works
 #  with openapi v3
 https://github.com/zalando/connexion/archive/dev-2.0.zip

--- a/python-flask-spid/spid.py
+++ b/python-flask-spid/spid.py
@@ -3,18 +3,16 @@ import socket
 from base64 import b64encode
 from os.path import join as pjoin
 
+from connexion import problem
+from flask import current_app as app
+from flask import make_response, redirect, request, session
 from lxml.etree import parse
+from onelogin.saml2.auth import OneLogin_Saml2_Auth
+from onelogin.saml2.constants import OneLogin_Saml2_Constants
+from onelogin.saml2.utils import OneLogin_Saml2_Utils
 from requests import get
 from six import StringIO
 from six.moves.urllib.parse import urlparse
-
-from connexion import problem
-from flask import current_app as app
-from flask import make_response, redirect, render_template, request, session
-from onelogin.saml2.auth import OneLogin_Saml2_Auth
-from onelogin.saml2.constants import OneLogin_Saml2_Constants
-from onelogin.saml2.settings import OneLogin_Saml2_Settings
-from onelogin.saml2.utils import OneLogin_Saml2_Utils
 
 logging.basicConfig(level=logging.DEBUG)
 root = logging.getLogger()
@@ -286,7 +284,7 @@ def test_init_saml_authapp():
         req = prepare_flask_request(request)
         auth = init_saml_auth(req, app.config)
         current_ip = socket.gethostbyname(socket.gethostname())
-        settings = auth.get_settings()
+        auth.get_settings()
         assert current_ip in auth.get_settings().get_sp_data()["entityId"]
 
 
@@ -313,7 +311,6 @@ def get_saml(sso=None, slo=None, return_to=""):
     not_auth_warn = False
     success_slo = False
     attributes = False
-    paint_logout = False
 
     # Redirect requests to IdP
     if sso is not None:

--- a/python-flask-spid/tox.ini
+++ b/python-flask-spid/tox.ini
@@ -6,12 +6,19 @@ skipsdist = True
 deps = -rrequirements.txt
        -rrequirements-test.txt
 commands =
-	nosetests -vs {posargs} test_oas.py
+  nosetests -vs {posargs} test_oas.py
 
 [testenv:reformat]
 whitelist_externals =
     sh
-deps = py27: -rrequirements.txt
+deps =
+  autopep8
+  isort
+  autoflake
+  flake8
 commands = 
-	sh -c 'isort *.py'
-	sh -c 'autopep8 -i *.py'
+  sh -c 'isort -y *.py'
+  sh -c 'autopep8 -i *.py'
+  sh -c 'autoflake --remove-all-unused-imports --remove-unused-variables --in-place *.py'
+  sh -c 'flake8 *.py'
+

--- a/python-flask/logging.yaml
+++ b/python-flask/logging.yaml
@@ -1,0 +1,25 @@
+#
+# Flask log configuration.
+#
+version: 1
+formatters:
+  # Avoid Flask sending the timestamp twice in the message.
+  fmt_syslog:
+    format: '%(levelname)s in %(module)s: %(message)s'
+handlers:
+  syslog:
+    class: logging.handlers.SysLogHandler
+    level: DEBUG
+  # This handler converts log in UTC before sending them to syslog.
+  rfc5424:
+    class: rfc5424logging.Rfc5424SysLogHandler
+    level: DEBUG
+    utc_timestamp: True
+    formatter: fmt_syslog
+# Use the rfc5424 handler by default.
+root:
+  level: DEBUG
+  handlers:
+  - rfc5424
+
+

--- a/python-flask/requirements.txt
+++ b/python-flask/requirements.txt
@@ -1,4 +1,5 @@
 connexion == 1.1.15
 python_dateutil == 2.6.0
+pyOpenSSL==18.0.0
 setuptools >= 21.0.0
-pyOpenSSL
+rfc5424-logging-handler==1.2.1

--- a/python-flask/swagger_server/__main__.py
+++ b/python-flask/swagger_server/__main__.py
@@ -1,11 +1,27 @@
 #!/usr/bin/env python3
 
-import connexion
+from logging import basicConfig
+from logging.config import dictConfig
+from os.path import isfile
 
+import connexion
+import yaml
 from swagger_server import encoder
 
 
+def configure_logger(log_config='logging.yaml'):
+    """Configure the logging subsystem."""
+    if not isfile(log_config):
+        return basicConfig()
+
+    with open(log_config) as fh:
+        log_config = yaml.load(fh)
+        return dictConfig(log_config)
+
+
 def main():
+    configure_logger()
+
     app = connexion.App(__name__, specification_dir='./swagger/')
     app.app.json_encoder = encoder.JSONEncoder
     app.add_api('swagger.yaml', arguments={'title': 'Ora esatta.'})

--- a/python-flask/swagger_server/controllers/public_controller.py
+++ b/python-flask/swagger_server/controllers/public_controller.py
@@ -2,7 +2,6 @@ import datetime
 from random import randint
 
 from connexion import problem
-
 from swagger_server.models.timestamps import Timestamps  # noqa: E501
 
 

--- a/python-flask/swagger_server/test/test_public_controller.py
+++ b/python-flask/swagger_server/test/test_public_controller.py
@@ -2,11 +2,6 @@
 
 from __future__ import absolute_import
 
-from flask import json
-from six import BytesIO
-
-from swagger_server.models.problem import Problem  # noqa: E501
-from swagger_server.models.timestamps import Timestamps  # noqa: E501
 from swagger_server.test import BaseTestCase
 
 

--- a/python-flask/tox.ini
+++ b/python-flask/tox.ini
@@ -11,7 +11,13 @@ commands=
       []
 
 [testenv:reformat]
-deps = autopep8 isort
+deps =
+  autopep8
+  isort
+  autoflake
+  flake8
 commands =
-  autopep8 -ri swagger_codegen
-  isort -r -y  swagger_codegen
+  autopep8 --recursive -i swagger_server
+  isort -rc -y  swagger_server
+  autoflake --remove-all-unused-imports  --remove-unused-variables --recursive --in-place swagger_server
+  flake8 swagger_server


### PR DESCRIPTION
## This PR

- Configure python apps to use an rfc5424 syslog handler 

## It's done

  - using dictConfig and a yaml file
  - importing rfc5424-logging-handler