### PR TITLE
Fix: #2. Update connexion version, lock openapi-resolver version.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ python-flask: python-flask-generate
 
 python-flask-spid: openapi/spid.yaml
 	cp openapi/spid.yaml python-flask-spid/spid.yaml
-	(cd python-flask-spid && docker-compose up --build simple spid-testenv)
+	(cd python-flask-spid && docker-compose up --build simple idp)
 
 python-flask-quickstart: python-flask-generate
 	# Test all

--- a/README.md
+++ b/README.md
@@ -46,6 +46,20 @@ Il file `Makefile` contiene:
 Il generatore non sovrascrive i file contenuti in `.swagger-codegen-ignore`.
 
 
+  - un esempio completo di API native in OAS3 che si autenticano con uno SPID IDP 
+    di test.  Per fare il build dei container con l'IDP e l'API lanciare:
+
+        make python-flask-spid
+
+    Le applicazioni verranno servite sugli IP dei container docker, che e' possibile
+    individuare utilizzando
+
+        docker inspect --format '{{.Name}} {{.NetworkSettings.IPAddress}} {{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' [ELENCO DEI CONTAINER]
+
+    Se l'API non trova l'IDP, basta ricrearlo con:
+
+        docker-compose up -d idp 
+
 ## Python
 
 ### Usare HTTPS

--- a/python-flask-spid/requirements.txt
+++ b/python-flask-spid/requirements.txt
@@ -5,8 +5,4 @@ decorator==4.3.0
 nose
 rfc5424-logging-handler
 swagger-ui-bundle==0.0.2
-
-# Use development version which works
-#  with openapi v3
-https://github.com/zalando/connexion/archive/dev-2.0.zip
-
+connexion == 2.2.0

--- a/python-flask/requirements.txt
+++ b/python-flask/requirements.txt
@@ -1,4 +1,4 @@
-connexion == 1.1.15
+connexion == 2.2.0
 python_dateutil == 2.6.0
 pyOpenSSL==18.0.0
 setuptools >= 21.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-connexion == 1.1.15
+connexion == 2.2.0
 python_dateutil == 2.6.0
 setuptools >= 21.0.0
 pyOpenSSL
 coverage>=4.0.3
 nose>=1.3.7
-openapi_resolver>=0.0.2
+openapi_resolver==0.0.2
 yamllint


### PR DESCRIPTION
## This PR

- bumps connexion == 2.2.0
- locks openapi-resolver == 0.0.2